### PR TITLE
Replace unmaintained "users" with "uzers"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,11 +19,11 @@ dependencies = [
  "rlimit",
  "tempfile",
  "textwrap",
- "users",
  "uu_chacl",
  "uu_getfacl",
  "uu_setfacl",
  "uucore",
+ "uzers",
  "xattr",
 ]
 
@@ -556,16 +556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,8 +574,8 @@ name = "uu_getfacl"
 version = "0.0.1"
 dependencies = [
  "clap",
- "users",
  "uucore",
+ "uzers",
  "xattr",
 ]
 
@@ -629,6 +619,16 @@ name = "uuhelp_parser"
 version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d841f8408028085ca65896cdd60b9925d4e407cb69989a64889f2bebbb51147b"
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.9.0"
 rand = { version = "0.8", features = ["small_rng"] }
 utmpx = "0.1"
 clap_mangen = "0.2.20"
-users = "0.11"
+uzers = "0.11"
 
 [dependencies]
 clap = { workspace = true }
@@ -56,7 +56,7 @@ uucore = { workspace = true }
 phf = { workspace = true }
 textwrap = { workspace = true }
 xattr = { workspace = true }
-users = { workspace = true }
+uzers = { workspace = true }
 
 
 #

--- a/src/uu/getfacl/Cargo.toml
+++ b/src/uu/getfacl/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 uucore = { workspace = true }
 clap = { workspace = true }
 xattr = { workspace = true }
-users = { workspace = true }
+uzers = { workspace = true }
 
 [lib]
 path = "src/getfacl.rs"

--- a/src/uu/getfacl/src/getfacl.rs
+++ b/src/uu/getfacl/src/getfacl.rs
@@ -6,8 +6,8 @@
 use clap::{crate_version, Arg, ArgAction, Command};
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
-use users::{get_group_by_gid, get_user_by_uid};
 use uucore::{error::UResult, help_about, help_usage};
+use uzers::{get_group_by_gid, get_user_by_uid};
 
 const ABOUT: &str = help_about!("getfacl.md");
 const USAGE: &str = help_usage!("getfacl.md");


### PR DESCRIPTION
This PR replaces the unmaintained `users` crate with its maintained fork `uzers` and fixes the issue mentioned in https://github.com/advisories/GHSA-jcr6-4frq-9gjj