### PR TITLE
Cargo.toml: add uudoc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ build = "build.rs"
 
 [features]
 default = ["feat_common_core"]
+uudoc = []
 
 feat_common_core = [
   "chacl",


### PR DESCRIPTION
This PR adds `uudoc` as a feature to get rid of the following warning shown when compiling:
```
warning: invalid feature `uudoc` in required-features of target `uudoc`: `uudoc` is not present in [features] section
```