### PR TITLE
setfacl: set `last(true)` for arg with `num_args` set

### DIFF
--- a/src/uu/setfacl/src/setfacl.rs
+++ b/src/uu/setfacl/src/setfacl.rs
@@ -106,5 +106,10 @@ pub fn uu_app() -> Command {
         .arg(Arg::new("test").long("test").help(
             "Test mode. Instead of changing the ACLs of any files, the resulting ACLs are listed",
         ))
-        .arg(Arg::new("option").action(ArgAction::Set).num_args(0..))
+        .arg(
+            Arg::new("option")
+                .action(ArgAction::Set)
+                .num_args(0..)
+                .last(true),
+        )
 }


### PR DESCRIPTION
When running `cargo run setfacl --help`, the following error is shown:
```
thread 'main' panicked at /home/dho/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.1/src/builder/debug_asserts.rs:584:9:
Positional argument `[option]...` *must* have `required(true)` or `last(true)` set because a prior positional argument (`<FILE>...`) has `num_args(1..)`
```
This PR fixes this issue by setting `last(true)`.