### PR TITLE
setfacl: adapt exit code in test

### DIFF
--- a/tests/by-util/test_setfacl.rs
+++ b/tests/by-util/test_setfacl.rs
@@ -8,5 +8,6 @@ use crate::common::util::TestScenario;
 
 #[test]
 fn test_invalid_arg() {
-    new_ucmd!().arg("--definitely-invalid").fails().code_is(101);
+    // TODO: clap sets an exit code of 1 by default, however, setfacl returns 2
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
 }


### PR DESCRIPTION
My previous [PR](https://github.com/uutils/acl/pull/12) unfortunately made the two "cargo test" checks in the CI fail. This PR makes them pass again.