### PR TITLE
tests: remove two unnecessary ".write(true)"

### DIFF
--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -862,7 +862,6 @@ impl AtPath {
     pub fn append(&self, name: &str, contents: &str) {
         log_info("write(append)", self.plus_as_string(name));
         let mut f = OpenOptions::new()
-            .write(true)
             .append(true)
             .create(true)
             .open(self.plus(name))
@@ -874,7 +873,6 @@ impl AtPath {
     pub fn append_bytes(&self, name: &str, contents: &[u8]) {
         log_info("write(append)", self.plus_as_string(name));
         let mut f = OpenOptions::new()
-            .write(true)
             .append(true)
             .create(true)
             .open(self.plus(name))


### PR DESCRIPTION
This PR removes two `.write(true)` calls in order to fix warnings from the [ineffective_open_options](https://rust-lang.github.io/rust-clippy/master/index.html#/ineffective_open_options) lint.