### PR TITLE
Cargo.toml: remove `sysinfo`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
 
 regex = "1.10.4"
-sysinfo = "0.33.0"
 libc = "0.2.154"
 phf = "0.11.2"
 phf_codegen = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,31 +32,30 @@ feat_common_core = [
 ]
 
 [workspace.dependencies]
-uucore = "0.0.30"
 clap = { version = "4.5.4", features = ["wrap_help", "cargo"] }
 clap_complete = "4.5.2"
-
-regex = "1.10.4"
+clap_mangen = "0.2.20"
 libc = "0.2.154"
 phf = "0.11.2"
 phf_codegen = "0.11.2"
-textwrap = { version = "0.16.1", features = ["terminal_size"] }
-xattr = "1.3.1"
-tempfile = "3.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
+regex = "1.10.4"
+tempfile = "3.10.1"
+textwrap = { version = "0.16.1", features = ["terminal_size"] }
 utmpx = "0.2"
-clap_mangen = "0.2.20"
+uucore = "0.0.30"
 uzers = "0.12"
+xattr = "1.3.1"
 
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }
-uucore = { workspace = true }
 phf = { workspace = true }
 textwrap = { workspace = true }
-xattr = { workspace = true }
+uucore = { workspace = true }
 uzers = { workspace = true }
+xattr = { workspace = true }
 
 
 #
@@ -65,11 +64,11 @@ getfacl = { optional = true, version = "0.0.1", package = "uu_getfacl", path = "
 setfacl = { optional = true, version = "0.0.1", package = "uu_setfacl", path = "src/uu/setfacl" }
 
 [dev-dependencies]
+libc = { workspace = true }
 pretty_assertions = "1.4.0"
+rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-libc = { workspace = true }
-rand = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
 
 [target.'cfg(unix)'.dev-dependencies]


### PR DESCRIPTION
This PR removes the unused `sysinfo` dependency. It also sorts the dependencies alphabetically.