### PR TITLE
Bump `rand` & adapt tests to its API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "phf_codegen",
  "pretty_assertions",
  "procfs",
- "rand",
+ "rand 0.9.0",
  "regex",
  "rlimit",
  "tempfile",
@@ -254,24 +254,13 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "windows-targets",
 ]
 
@@ -427,7 +416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -501,19 +490,28 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -521,8 +519,14 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
 ]
 
 [[package]]
@@ -643,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom",
  "once_cell",
  "rustix 1.0.0",
  "windows-sys 0.59.0",
@@ -772,12 +776,6 @@ dependencies = [
  "libc",
  "log",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -976,3 +974,23 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap_mangen = "0.2.20"
 libc = "0.2.154"
 phf = "0.11.2"
 phf_codegen = "0.11.2"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 regex = "1.10.4"
 tempfile = "3.10.1"
 textwrap = { version = "0.16.1", features = ["terminal_size"] }

--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -3,8 +3,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use rand::distributions::{Distribution, Uniform};
-use rand::{thread_rng, Rng};
+use rand::distr::{Distribution, Uniform};
+use rand::{rng, Rng};
 
 /// Samples alphanumeric characters `[A-Za-z0-9]` including newline `\n`
 ///
@@ -38,7 +38,7 @@ impl AlphanumericNewline {
     where
         R: Rng + ?Sized,
     {
-        let idx = rng.gen_range(0..Self::CHARSET.len());
+        let idx = rng.random_range(0..Self::CHARSET.len());
         Self::CHARSET[idx]
     }
 }
@@ -80,7 +80,7 @@ impl RandomString {
     where
         D: Distribution<u8>,
     {
-        thread_rng()
+        rng()
             .sample_iter(dist)
             .take(length)
             .map(|b| b as char)
@@ -132,15 +132,15 @@ impl RandomString {
             return if num_delimiter > 0 {
                 String::from(delimiter as char)
             } else {
-                String::from(thread_rng().sample(&dist) as char)
+                String::from(rng().sample(&dist) as char)
             };
         }
 
         let samples = length - 1;
-        let mut result: Vec<u8> = thread_rng().sample_iter(&dist).take(samples).collect();
+        let mut result: Vec<u8> = rng().sample_iter(&dist).take(samples).collect();
 
         if num_delimiter == 0 {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
             return String::from_utf8(result).unwrap();
         }
 
@@ -150,9 +150,10 @@ impl RandomString {
             num_delimiter
         };
 
-        let between = Uniform::new(0, samples);
+        // safe to unwrap because samples is at least 1, thus high > low
+        let between = Uniform::new(0, samples).unwrap();
         for _ in 0..num_delimiter {
-            let mut pos = between.sample(&mut thread_rng());
+            let mut pos = between.sample(&mut rng());
             let turn = pos;
             while result[pos] == delimiter {
                 pos += 1;
@@ -169,7 +170,7 @@ impl RandomString {
         if end_with_delimiter {
             result.push(delimiter);
         } else {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
         }
 
         String::from_utf8(result).unwrap()
@@ -179,7 +180,7 @@ impl RandomString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::distributions::Alphanumeric;
+    use rand::distr::Alphanumeric;
 
     #[test]
     fn test_random_string_generate() {


### PR DESCRIPTION
This PR bumps `rand` from `0.8.5` to `0.9.0` and adapts `tests/common/random.rs` to the API changes.