### PR TITLE
clippy: fix warnings from `uninlined_format_args`

### DIFF
--- a/src/uu/chacl/src/chacl.rs
+++ b/src/uu/chacl/src/chacl.rs
@@ -15,7 +15,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // Example: Handle pathname arguments
     if let Some(pathnames) = matches.get_many::<String>("pathname") {
         for pathname in pathnames {
-            println!("Would change ACL for pathname: {}", pathname);
+            println!("Would change ACL for pathname: {pathname}");
             // Here you would implement the logic to change the ACLs
         }
     }

--- a/src/uu/getfacl/src/getfacl.rs
+++ b/src/uu/getfacl/src/getfacl.rs
@@ -46,12 +46,12 @@ fn print_file_acl(file_path: &str) -> std::io::Result<()> {
     );
 
     // Generating the output
-    println!("# file: {}", file_path);
-    println!("# owner: {}", owner);
-    println!("# group: {}", group);
-    println!("user::{}", user_perms);
-    println!("group::{}", group_perms);
-    println!("other::{}", other_perms);
+    println!("# file: {file_path}");
+    println!("# owner: {owner}");
+    println!("# group: {group}");
+    println!("user::{user_perms}");
+    println!("group::{group_perms}");
+    println!("other::{other_perms}");
 
     Ok(())
 }
@@ -81,7 +81,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                         }
                     }
                 }
-                Err(e) => println!("Error listing attributes for file {}: {}", file, e),
+                Err(e) => println!("Error listing attributes for file {file}: {e}"),
             }
         }
     }

--- a/src/uu/setfacl/src/setfacl.rs
+++ b/src/uu/setfacl/src/setfacl.rs
@@ -18,7 +18,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     println!("setfacl options selected:");
     for option in matches.get_many::<String>("option").unwrap_or_default() {
-        println!("Option: {}", option);
+        println!("Option: {option}");
     }
 
     Ok(())


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint.