### PR TITLE
Bump `ctor` from `0.4.1` to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.4.3",
+ "ctor",
  "libc",
  "phf",
  "phf_codegen",
@@ -171,22 +171,12 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "ctor"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
-dependencies = [
- "ctor-proc-macro",
- "dtor 0.0.6",
-]
-
-[[package]]
-name = "ctor"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
  "ctor-proc-macro",
- "dtor 0.1.0",
+ "dtor",
 ]
 
 [[package]]
@@ -235,27 +225,12 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
-dependencies = [
- "dtor-proc-macro 0.0.5",
-]
-
-[[package]]
-name = "dtor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
 dependencies = [
- "dtor-proc-macro 0.0.6",
+ "dtor-proc-macro",
 ]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -1002,7 +977,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b5908554cef4685dc17d0a5d547f85e8f915b2982ed6cb1b753f7ae47bf915"
 dependencies = [
- "ctor 0.5.0",
+ "ctor",
  "libc",
  "nix",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ getfacl = { optional = true, version = "0.0.1", package = "uu_getfacl", path = "
 setfacl = { optional = true, version = "0.0.1", package = "uu_setfacl", path = "src/uu/setfacl" }
 
 [dev-dependencies]
-ctor = "0.4.1"
+ctor = "0.5.0"
 libc = { workspace = true }
 pretty_assertions = "1.4.0"
 regex = { workspace = true }


### PR DESCRIPTION
This PR manually bumps `ctor` from `0.4.1` to `0.5.0` because renovate fails with a "Artifact update problem" in https://github.com/uutils/acl/pull/191.