### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.12.0",
+ "ctor 1.0.1",
  "libc",
  "phf",
  "phf_codegen",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -487,9 +487,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ getfacl = { optional = true, version = "0.0.1", package = "uu_getfacl", path = "
 setfacl = { optional = true, version = "0.0.1", package = "uu_setfacl", path = "src/uu/setfacl" }
 
 [dev-dependencies]
-ctor = "0.12.0"
+ctor = "1.0.0"
 libc = { workspace = true }
 pretty_assertions = "1.4.0"
 regex = { workspace = true }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,7 +8,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_acl");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`0.13.0`</del><del>`1.0.0`</del>`1.0.1` and adapts `tests/tests.rs` to a change in `ctor`.