### PR TITLE
Acl dev full panics

### DIFF
--- a/src/bin/acl.rs
+++ b/src/bin/acl.rs
@@ -20,15 +20,17 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 include!(concat!(env!("OUT_DIR"), "/uutils_map.rs"));
 
 fn usage<T>(utils: &UtilityMap<T>, name: &str) {
-    println!("{name} {VERSION} (multi-call binary)\n");
-    println!("Usage: {name} [function [arguments...]]\n");
-    println!("Currently defined functions:\n");
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "{name} {VERSION} (multi-call binary)\n");
+    let _ = writeln!(stdout, "Usage: {name} [function [arguments...]]\n");
+    let _ = writeln!(stdout, "Currently defined functions:\n");
     #[allow(clippy::map_clone)]
     let mut utils: Vec<&str> = utils.keys().map(|&s| s).collect();
     utils.sort_unstable();
     let display_list = utils.join(", ");
     let width = cmp::min(textwrap::termwidth(), 100) - 4 * 2; // (opinion/heuristic) max 100 chars wide with 4 character side indentions
-    println!(
+    let _ = writeln!(
+        stdout,
         "{}",
         textwrap::indent(&textwrap::fill(&display_list, width), "    ")
     );
@@ -81,7 +83,12 @@ fn main() {
     // 0th argument equals util name?
     if let Some(util_os) = util_name {
         fn not_found(util: &OsStr) -> ! {
-            println!("{}: function/utility not found", util.maybe_quote());
+            let _ = writeln!(
+                io::stdout(),
+                "{}: function/utility not found",
+                util.maybe_quote()
+            );
+
             process::exit(1);
         }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,6 @@
 // file that was distributed with this source code.
 
 use std::env;
-use uutests::new_ucmd;
 
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_acl");
 
@@ -17,10 +16,41 @@ fn init() {
     }
 }
 
+/// Regression test to ensure the acl binary handles write errors gracefully
+/// when stdout is redirected to /dev/full instead of panicking.
+///
+/// This test verifies the fix for the issue where the binary would panic with:
+/// "thread 'main' panicked at failed printing to stdout: No space left on device"
+///
+/// Expected behavior:
+/// - The command should NOT panic (exit code 134/SIGABRT)
+/// - The command should handle the write error gracefully
 #[test]
-fn test_println_panic() {
-    // This test is to ensure that println!() does not panic when it is unable to write to stdout
-    new_ucmd!().arg("> /dev/full").fails().code_is(1);
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
+fn test_acl_binary_write_error_to_dev_full_no_panic() {
+    use std::fs::OpenOptions;
+    use std::process::Command;
+
+    // Open /dev/full for stdout redirection
+    let dev_full = OpenOptions::new()
+        .write(true)
+        .open("/dev/full")
+        .expect("Failed to open /dev/full");
+
+    // Run the acl binary (with no arguments, which prints usage) with stdout redirected to /dev/full
+    let result = Command::new(TESTS_BINARY)
+        .stdout(dev_full)
+        .status()
+        .expect("Failed to execute acl binary");
+
+    // The command should NOT panic with SIGABRT (exit code 134)
+    // A panic would cause SIGABRT which typically results in exit code 134
+    let code = result.code().unwrap_or(0);
+    assert_ne!(code, 134,
+        "acl binary panicked when writing to /dev/full (exit code 134/SIGABRT). \
+         This means println! macros or .unwrap()/.expect() on write operations are still being used.");
+
+    // If we get here without panicking, the test passes
 }
 
 #[cfg(feature = "chacl")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,9 +46,11 @@ fn test_acl_binary_write_error_to_dev_full_no_panic() {
     // The command should NOT panic with SIGABRT (exit code 134)
     // A panic would cause SIGABRT which typically results in exit code 134
     let code = result.code().unwrap_or(0);
-    assert_ne!(code, 134,
+    assert_ne!(
+        code, 134,
         "acl binary panicked when writing to /dev/full (exit code 134/SIGABRT). \
-         This means println! macros or .unwrap()/.expect() on write operations are still being used.");
+         This means println! macros or .unwrap()/.expect() on write operations are still being used."
+    );
 
     // If we get here without panicking, the test passes
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -27,7 +27,7 @@ fn init() {
 /// - The command should handle the write error gracefully
 #[test]
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
-fn test_acl_binary_write_error_to_dev_full_no_panic() {
+fn test_acl_binary_write_error_no_panic() {
     use std::fs::OpenOptions;
     use std::process::Command;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,7 @@
 // file that was distributed with this source code.
 
 use std::env;
+use uutests::new_ucmd;
 
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_acl");
 
@@ -14,6 +15,12 @@ fn init() {
         // Necessary for uutests to be able to find the binary
         std::env::set_var("UUTESTS_BINARY_PATH", TESTS_BINARY);
     }
+}
+
+#[test]
+fn test_println_panic() {
+    // This test is to ensure that println!() does not panic when it is unable to write to stdout
+    new_ucmd!().arg("> /dev/full").fails().code_is(1);
 }
 
 #[cfg(feature = "chacl")]


### PR DESCRIPTION
Addresses https://github.com/uutils/acl/issues/254.

Solution: Use `writeln` to put data in `stdout` instead of using `println` directly.